### PR TITLE
feat: improve api handler

### DIFF
--- a/serpens/api.py
+++ b/serpens/api.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass
 from functools import wraps
 
 
@@ -25,11 +24,13 @@ def handler(func):
     return wrapper
 
 
-@dataclass
 class Authorizer:
-    partner_id: int = None
-    product_id: int = None
-    borrower_id: int = None
+    def __init__(self, data):
+        for key, value in data.items():
+            setattr(self, key, value)
+
+    def __repr__(self):
+        return str(self.__dict__)
 
 
 class Request:
@@ -40,13 +41,12 @@ class Request:
 
     def _authorizer(self):
         context = self.data.get("requestContext") or {}
-        partner_id = context.get("authorizer").get("partner_id")
-        product_id = context.get("authorizer").get("product_id")
-        borrower_id = context.get("authorizer").get("borrower_id")
-        Authorizer(partner_id, product_id, borrower_id)
+        authorizer = context.get("authorizer") or {}
+        return Authorizer(authorizer)
 
     def _body(self):
+        body = self.data.get("body") or ""
         try:
-            return json.loads(self.data)
+            return json.loads(body)
         except json.JSONDecodeError:
-            return self.data
+            return body

--- a/serpens/api.py
+++ b/serpens/api.py
@@ -1,21 +1,18 @@
+import json
+from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Dict
 
 
-def handler(func: Callable) -> Callable:
+def handler(func):
     @wraps(func)
-    def wrapper(
-        event: Dict[str, Any],
-        context: Dict[str, Any],
-        *args: Any,
-        **kwargs: Any
-    ) -> Dict[str, Any]:
+    def wrapper(event, context):
         response = {
             "headers": {"Access-Control-Allow-Origin": "*"},
             "statusCode": 200,
             "body": "",
         }
-        result = func(event, context)
+        request = Request(event)
+        result = func(request)
 
         if isinstance(result, tuple) and isinstance(result[0], int):
             response["statusCode"] = result[0]
@@ -26,3 +23,30 @@ def handler(func: Callable) -> Callable:
         return response
 
     return wrapper
+
+
+@dataclass
+class Authorizer:
+    partner_id: int = None
+    product_id: int = None
+    borrower_id: int = None
+
+
+class Request:
+    def __init__(self, data):
+        self.data = data
+        self.authorizer = self._authorizer()
+        self.body = self._body()
+
+    def _authorizer(self):
+        context = self.data.get("requestContext") or {}
+        partner_id = context.get("authorizer").get("partner_id")
+        product_id = context.get("authorizer").get("product_id")
+        borrower_id = context.get("authorizer").get("borrower_id")
+        Authorizer(partner_id, product_id, borrower_id)
+
+    def _body(self):
+        try:
+            return json.loads(self.data)
+        except json.JSONDecodeError:
+            return self.data

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,61 @@
+import json
+import unittest
+
+import api
+
+
+class TestApiAuthorizer(unittest.TestCase):
+    def test_instance(self):
+        data = {"foo": "bar", "baz": 1}
+        instance = api.Authorizer(data)
+
+        self.assertIsInstance(instance, api.Authorizer)
+        self.assertTrue(hasattr(instance, "foo"))
+        self.assertTrue(hasattr(instance, "baz"))
+        self.assertEqual(instance.foo, "bar")
+        self.assertEqual(instance.baz, 1)
+        self.assertEqual(str(instance), str(data))
+
+
+class TestApiRequest(unittest.TestCase):
+    def test_instance(self):
+        data = {
+            "requestContext": {"authorizer": {"foo": "bar", "baz": 1}},
+            "body": '{"ping": "pong"}',
+        }
+        instance = api.Request(data)
+
+        self.assertIsInstance(instance, api.Request)
+        self.assertTrue(hasattr(instance, "authorizer"))
+        self.assertTrue(hasattr(instance, "body"))
+        self.assertTrue(instance.authorizer.foo, "bar")
+        self.assertTrue(instance.authorizer.baz, 1)
+        self.assertTrue(instance.body, {"ping": "pong"})
+
+
+class TestApiHandler(unittest.TestCase):
+    def test_handler(self):
+        event = {
+            "requestContext": {"authorizer": {"foo": "bar", "baz": 1}},
+            "body": '{"ping": "pong"}',
+        }
+        context = {"nothing": "here"}
+        expected = {
+            "headers": {"Access-Control-Allow-Origin": "*"},
+            "statusCode": 200,
+            "body": {"foo": "bar", "ping": "pong"},
+        }
+
+        @api.handler
+        def handler(request):
+            res = {"foo": request.authorizer.foo, "ping": request.body["ping"]}
+            return json.dumps(res)
+
+        response = handler(event, context)
+
+        self.assertIn("headers", response)
+        self.assertIn("statusCode", response)
+        self.assertIn("body", response)
+        self.assertEqual(response["headers"], expected["headers"])
+        self.assertEqual(response["statusCode"], expected["statusCode"])
+        self.assertDictEqual(json.loads(response["body"]), expected["body"])


### PR DESCRIPTION
### Contain
- [x] Tests
- [x] Breaking changes

### Details
* Update api handler to inject a request object that contains the full event data, an attribute called `authorizer` and another called `body`. The `authorizer` maps whatever came inside the requestContext->authorizer, and the body returns a dict if the content is "json serializable", otherwise the content as is.

```python
import api

@api.handler
def my_handler(request):
    # accessing request info
    print(request.authorizer.some_id)
    print(request.body)
    ...
```

* Add tests.
