### PR TITLE
feat: add base class for schema validation

### DIFF
--- a/serpens/schema.py
+++ b/serpens/schema.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, fields
+
+
+@dataclass
+class Schema:
+    def __post_init__(self):
+        errors = []
+        for field in fields(self):
+            if not isinstance(getattr(self, field.name), field.type):
+                msg = f"'{field.name}' must be of type {field.type.__name__}"
+                errors.append(msg)
+        if errors:
+            raise TypeError(*errors)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,34 @@
+import unittest
+from dataclasses import dataclass, field
+
+from schema import Schema
+
+
+@dataclass
+class PersonSchema(Schema):
+    name: str
+    age: int
+    hobby: list = field(default_factory=list)
+
+
+class TestSchema(unittest.TestCase):
+    def test_missing_required(self):
+        expected = (
+            (
+                "__init__() missing 2 required positional "
+                + "arguments: 'name' and 'age'"
+            ),
+        )
+
+        with self.assertRaises(TypeError) as error:
+            PersonSchema()
+
+        self.assertEqual(error.exception.args, expected)
+
+    def test_invalid_type(self):
+        expected = ("'age' must be of type int",)
+
+        with self.assertRaises(TypeError) as error:
+            PersonSchema("foo", "bar")
+
+        self.assertEqual(error.exception.args, expected)


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Add a new base class to help with schema validation. This base class uses Python's type annotation to validate inputted data.

```python
from dataclasses import dataclass

from schema import Schema


@dataclass
class PersonSchema(Schema):
    name: str
    age: int

>>> Person('John', 18)
... Person(name=John, age=18)
>>> Person('Foo', 'Bar')
... TypeError: ("'age' must be of type int",)
```