### PR TITLE
feat: add load, loads, dump and dumps methods for schemas

### DIFF
--- a/serpens/schema.py
+++ b/serpens/schema.py
@@ -1,4 +1,9 @@
-from dataclasses import dataclass, fields
+import json
+from copy import deepcopy
+from dataclasses import asdict, dataclass, fields, is_dataclass
+from datetime import date, datetime, time
+from decimal import Decimal
+from uuid import UUID
 
 
 @dataclass
@@ -11,3 +16,50 @@ class Schema:
                 errors.append(msg)
         if errors:
             raise TypeError(*errors)
+
+    @classmethod
+    def load(cls, dictionary, many=False):
+        data = deepcopy(dictionary)
+
+        if many:
+            return list(map(cls.load, data))
+
+        for field in fields(cls):
+            if field.name not in data or data[field.name] is None:
+                continue
+            # cast special types
+            if field.type in (date, datetime, time):
+                data[field.name] = field.type.fromisoformat(data[field.name])
+            elif field.type in (Decimal, UUID):
+                data[field.name] = field.type(data[field.name])
+            elif is_dataclass(field.type):
+                data[field.name] = field.type.load(data[field.name])
+
+        return cls(**data)
+
+    @classmethod
+    def loads(cls, json_string, many=False):
+        data = json.loads(json_string)
+        return list(map(cls.load, data)) if many else cls.load(data)
+
+    @classmethod
+    def dump(cls, instance, many=False):
+        string = cls.dumps(instance, many)
+        return json.loads(string)
+
+    @classmethod
+    def dumps(cls, instance, many=False):
+        data = list(map(asdict, instance)) if many else asdict(instance)
+        return json.dumps(data, cls=SchemaEncoder)
+
+
+class SchemaEncoder(json.JSONEncoder):
+    def default(self, obj):
+        # cast special types
+        if isinstance(obj, (date, datetime, time)):
+            return obj.isoformat()
+        elif isinstance(obj, Decimal):
+            return float(obj)
+        elif isinstance(obj, UUID):
+            return str(obj)
+        return super().default(obj)

--- a/serpens/schema.py
+++ b/serpens/schema.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
+from enum import Enum
 from uuid import UUID
 
 
@@ -31,6 +32,8 @@ class Schema:
             if field.type in (date, datetime, time):
                 data[field.name] = field.type.fromisoformat(data[field.name])
             elif field.type in (Decimal, UUID):
+                data[field.name] = field.type(data[field.name])
+            elif issubclass(field.type, Enum):
                 data[field.name] = field.type(data[field.name])
             elif is_dataclass(field.type):
                 data[field.name] = field.type.load(data[field.name])
@@ -62,4 +65,6 @@ class SchemaEncoder(json.JSONEncoder):
             return float(obj)
         elif isinstance(obj, UUID):
             return str(obj)
+        elif isinstance(obj, Enum):
+            return obj.value
         return super().default(obj)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,9 +3,17 @@ import unittest
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
+from enum import Enum
 from uuid import UUID
 
 from schema import Schema
+
+
+class Level(Enum):
+    INTERN = "intern"
+    JUNIOR = "junior"
+    MIDDLE = "middle"
+    SENIOR = "senior"
 
 
 @dataclass
@@ -21,6 +29,7 @@ class EmployeeSchema(Schema):
     uid: UUID
     office: str
     salary: Decimal
+    level: Level
     registered: date
 
 
@@ -52,6 +61,7 @@ class TestSchema(unittest.TestCase):
             "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
             "office": "main",
             "salary": 6500.1,
+            "level": "middle",
             "registered": "2021-01-01",
         }
         instance = EmployeeSchema.load(data)
@@ -59,6 +69,7 @@ class TestSchema(unittest.TestCase):
         self.assertIsInstance(instance, EmployeeSchema)
         self.assertIsInstance(instance.person, PersonSchema)
         self.assertIsInstance(instance.salary, Decimal)
+        self.assertIsInstance(instance.level, Enum)
         self.assertIsInstance(instance.registered, date)
 
     def test_load_many(self):
@@ -68,6 +79,7 @@ class TestSchema(unittest.TestCase):
                 "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
                 "office": "main",
                 "salary": 6500.1,
+                "level": "middle",
                 "registered": "2021-01-01",
             }
         ]
@@ -77,6 +89,7 @@ class TestSchema(unittest.TestCase):
         self.assertIsInstance(instances[0], EmployeeSchema)
         self.assertIsInstance(instances[0].person, PersonSchema)
         self.assertIsInstance(instances[0].salary, Decimal)
+        self.assertIsInstance(instances[0].level, Enum)
         self.assertIsInstance(instances[0].registered, date)
 
     def test_loads(self):
@@ -86,6 +99,7 @@ class TestSchema(unittest.TestCase):
                 "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
                 "office": "main",
                 "salary": 6500.1,
+                "level": "middle",
                 "registered": "2021-01-01",
             }
         )
@@ -94,6 +108,7 @@ class TestSchema(unittest.TestCase):
         self.assertIsInstance(instance, EmployeeSchema)
         self.assertIsInstance(instance.person, PersonSchema)
         self.assertIsInstance(instance.salary, Decimal)
+        self.assertIsInstance(instance.level, Enum)
         self.assertIsInstance(instance.registered, date)
 
     def test_dump(self):
@@ -102,6 +117,7 @@ class TestSchema(unittest.TestCase):
             "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
             "office": "main",
             "salary": 6500.1,
+            "level": "middle",
             "registered": "2021-01-01",
         }
         instance = EmployeeSchema.load(expected)
@@ -116,6 +132,7 @@ class TestSchema(unittest.TestCase):
                 "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
                 "office": "main",
                 "salary": 6500.1,
+                "level": "middle",
                 "registered": "2021-01-01",
             }
         ]
@@ -131,6 +148,7 @@ class TestSchema(unittest.TestCase):
             "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
             "office": "main",
             "salary": 6500.1,
+            "level": "middle",
             "registered": "2021-01-01",
         }
         instance = EmployeeSchema.load(expected)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,9 @@
+import json
 import unittest
 from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
 
 from schema import Schema
 
@@ -9,6 +13,15 @@ class PersonSchema(Schema):
     name: str
     age: int
     hobby: list = field(default_factory=list)
+
+
+@dataclass
+class EmployeeSchema(Schema):
+    person: PersonSchema
+    uid: UUID
+    office: str
+    salary: Decimal
+    registered: date
 
 
 class TestSchema(unittest.TestCase):
@@ -32,3 +45,96 @@ class TestSchema(unittest.TestCase):
             PersonSchema("foo", "bar")
 
         self.assertEqual(error.exception.args, expected)
+
+    def test_load(self):
+        data = {
+            "person": {"name": "John Doe", "age": 30, "hobby": ["walk"]},
+            "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
+            "office": "main",
+            "salary": 6500.1,
+            "registered": "2021-01-01",
+        }
+        instance = EmployeeSchema.load(data)
+
+        self.assertIsInstance(instance, EmployeeSchema)
+        self.assertIsInstance(instance.person, PersonSchema)
+        self.assertIsInstance(instance.salary, Decimal)
+        self.assertIsInstance(instance.registered, date)
+
+    def test_load_many(self):
+        data = [
+            {
+                "person": {"name": "John Doe", "age": 30, "hobby": ["walk"]},
+                "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
+                "office": "main",
+                "salary": 6500.1,
+                "registered": "2021-01-01",
+            }
+        ]
+        instances = EmployeeSchema.load(data, many=True)
+
+        self.assertIsInstance(instances, list)
+        self.assertIsInstance(instances[0], EmployeeSchema)
+        self.assertIsInstance(instances[0].person, PersonSchema)
+        self.assertIsInstance(instances[0].salary, Decimal)
+        self.assertIsInstance(instances[0].registered, date)
+
+    def test_loads(self):
+        data = json.dumps(
+            {
+                "person": {"name": "John Doe", "age": 30, "hobby": ["walk"]},
+                "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
+                "office": "main",
+                "salary": 6500.1,
+                "registered": "2021-01-01",
+            }
+        )
+        instance = EmployeeSchema.loads(data)
+
+        self.assertIsInstance(instance, EmployeeSchema)
+        self.assertIsInstance(instance.person, PersonSchema)
+        self.assertIsInstance(instance.salary, Decimal)
+        self.assertIsInstance(instance.registered, date)
+
+    def test_dump(self):
+        expected = {
+            "person": {"name": "John Doe", "age": 30, "hobby": ["walk"]},
+            "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
+            "office": "main",
+            "salary": 6500.1,
+            "registered": "2021-01-01",
+        }
+        instance = EmployeeSchema.load(expected)
+        data = EmployeeSchema.dump(instance)
+
+        self.assertDictEqual(data, expected)
+
+    def test_dump_many(self):
+        expected = [
+            {
+                "person": {"name": "John Doe", "age": 30, "hobby": ["walk"]},
+                "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
+                "office": "main",
+                "salary": 6500.1,
+                "registered": "2021-01-01",
+            }
+        ]
+        instances = EmployeeSchema.load(expected, many=True)
+        data = EmployeeSchema.dump(instances, many=True)
+
+        self.assertIsInstance(data, list)
+        self.assertDictEqual(data[0], expected[0])
+
+    def test_dumps(self):
+        expected = {
+            "person": {"name": "John Doe", "age": 30, "hobby": ["walk"]},
+            "uid": "dc675e20-6e8b-4b05-a8ce-4459560526c3",
+            "office": "main",
+            "salary": 6500.1,
+            "registered": "2021-01-01",
+        }
+        instance = EmployeeSchema.load(expected)
+        string = EmployeeSchema.dumps(instance)
+
+        self.assertIsInstance(string, str)
+        self.assertDictEqual(json.loads(string), expected)


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Add methods to encode and decode data converting from json or json strings to an instance of the schema, and from an instance to a json (serializable) or json string.

```python
from dataclasses import dataclass

from schema import Schema


@dataclass
class PersonSchema(Schema):
    name: str
    age: int

>>> p = Person('John', 18)
>>> p
... Person(name=John, age=18)
>>> j = Person.dump(p)
>>> j
... {'name': 'John', 'age': 18}
>>> Person.load(j)
... Person(name=John, age=18)
```