### PR TITLE
feat: add method `get` to AttrDict class

### DIFF
--- a/serpens/api.py
+++ b/serpens/api.py
@@ -48,6 +48,9 @@ class AttrDict:
     def __repr__(self):
         return str(self.__dict__)
 
+    def get(self, name, default=None):
+        return getattr(self, name, default)
+
 
 class Request:
     def __init__(self, data):


### PR DESCRIPTION
This will allow to make use of safe access of an attribute, when a `None` value is returned in case of the attribute does not exists instead of raising an exception. It works exactly as the `get` method of dictionaries.