### PR TITLE
feat: improve request class

### DIFF
--- a/serpens/api.py
+++ b/serpens/api.py
@@ -1,6 +1,6 @@
 import json
-from functools import wraps
 import logging
+from functools import wraps
 
 try:
     from sentry_sdk import capture_exception
@@ -77,6 +77,8 @@ class Request:
         self.body = self._body()
         self.path = self._path()
         self.query = self._query()
+        self.headers = self._headers()
+        self.identity = self._identity()
 
     def _authorizer(self):
         context = self.data.get("requestContext") or {}
@@ -97,3 +99,12 @@ class Request:
     def _query(self):
         query = self.data.get("queryStringParameters") or {}
         return AttrDict(query)
+
+    def _headers(self):
+        headers = self.data.get("headers") or {}
+        return AttrDict(headers)
+
+    def _identity(self):
+        context = self.data.get("requestContext") or {}
+        identity = context.get("identity") or {}
+        return AttrDict(identity)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,10 +35,14 @@ class TestApiAttrDict(unittest.TestCase):
 class TestApiRequest(unittest.TestCase):
     def test_instance(self):
         data = {
-            "requestContext": {"authorizer": {"foo": "bar", "baz": 1}},
+            "requestContext": {
+                "authorizer": {"foo": "bar", "baz": 1},
+                "identity": {"sourceIp": "127.0.0.1"},
+            },
             "body": '{"ping": "pong"}',
             "pathParameters": {"one": 1, "two": 2},
             "queryStringParameters": {"limit": 10, "page": 2},
+            "headers": {"Accept": "*/*"},
         }
         instance = api.Request(data)
 
@@ -47,6 +51,8 @@ class TestApiRequest(unittest.TestCase):
         self.assertTrue(hasattr(instance, "body"))
         self.assertTrue(hasattr(instance, "path"))
         self.assertTrue(hasattr(instance, "query"))
+        self.assertTrue(hasattr(instance, "headers"))
+        self.assertTrue(hasattr(instance, "identity"))
         self.assertEqual(instance.authorizer.foo, "bar")
         self.assertEqual(instance.authorizer.baz, 1)
         self.assertEqual(instance.body, {"ping": "pong"})
@@ -54,6 +60,8 @@ class TestApiRequest(unittest.TestCase):
         self.assertEqual(instance.path.two, 2)
         self.assertEqual(instance.query.limit, 10)
         self.assertEqual(instance.query.page, 2)
+        self.assertEqual(instance.headers.Accept, "*/*")
+        self.assertEqual(instance.identity.sourceIp, "127.0.0.1")
 
 
 class TestApiHandler(unittest.TestCase):


### PR DESCRIPTION
* Add two extra "pre-parsed" attributes to the API helper class `Request`:
  * `headers` - HTTP request headers.
  * `identity` - AWS ApiGateway identity information.