### PR TITLE
Auto initialize setup on api.handle

### DIFF
--- a/serpens/api.py
+++ b/serpens/api.py
@@ -3,6 +3,8 @@ import logging
 from functools import wraps
 from dataclasses import is_dataclass, asdict
 
+import initializers
+
 try:
     from sentry_sdk import capture_exception
 
@@ -10,6 +12,8 @@ try:
 except ImportError:
     _SENTRY_SDK_MISSING_DEPS = True
 
+
+initializers.setup()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
We always use initializers.setup every place we decorete with
api.handler so it is better to setup it by default.


Now in places like this:

```python
from serpens import initializers, api

from proposal import Proposal, ProposalInfo


initializers.setup()

@api.handler
def score_proposal_handler(request: api.Request):
    req_info = ProposalInfo(**request.body)
    proposal = Proposal.get_proposal_for_score(req_info)

    return 200, proposal
```

we could use just:

```python
from serpens import api

from proposal import Proposal, ProposalInfo


@api.handler
def score_proposal_handler(request: api.Request):
    req_info = ProposalInfo(**request.body)
    proposal = Proposal.get_proposal_for_score(req_info)

    return 200, proposal
```

