### PR TITLE
Add treatment to undefined envvar

### DIFF
--- a/serpens/envvars.py
+++ b/serpens/envvars.py
@@ -8,6 +8,9 @@ from serpens import secrets
 def get(key, default=None):
     result = os.getenv(key, default)
 
+    if result is None:
+        return result
+
     if result.startswith("parameters://"):
         tmp = result.split("://")[1]
         return parameters.get(tmp)

--- a/serpens/envvars.py
+++ b/serpens/envvars.py
@@ -9,7 +9,7 @@ def get(key, default=None):
     result = os.getenv(key, default)
 
     if result is None:
-        return result
+        raise NameError(f"envvar '{key}' is not defined")
 
     if result.startswith("parameters://"):
         tmp = result.split("://")[1]

--- a/serpens/envvars.py
+++ b/serpens/envvars.py
@@ -9,7 +9,7 @@ def get(key, default=None):
     result = os.getenv(key, default)
 
     if result is None:
-        raise NameError(f"envvar '{key}' is not defined")
+        raise NameError(f"Environment var '{key}' is not defined")
 
     if result.startswith("parameters://"):
         tmp = result.split("://")[1]

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -32,6 +32,9 @@ class TestEnvVars(unittest.TestCase):
         os.environ["FOO"] = "BAR"
         self.assertEqual(envvars.get("FOO"), "BAR")
 
+    def test_get_unexisting_envvar(self):
+        self.assertIsNone(envvars.get("UNEXISTING_ENVVAR"))
+
     @patch("envvars.parameters.get")
     def test_get_parameter(self, mock_params):
         mock_params.return_value = "stored_value"

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -33,7 +33,8 @@ class TestEnvVars(unittest.TestCase):
         self.assertEqual(envvars.get("FOO"), "BAR")
 
     def test_get_unexisting_envvar(self):
-        self.assertIsNone(envvars.get("UNEXISTING_ENVVAR"))
+        with self.assertRaises(NameError):
+            envvars.get("UNEXISTING_ENVVAR")
 
     @patch("envvars.parameters.get")
     def test_get_parameter(self, mock_params):


### PR DESCRIPTION
- Add condition to treat undefined envvar.
- Raise exception if envvar is not defined.
- Update tests.
