### PR TITLE
fix: default header for api response class

### DIFF
--- a/serpens/api.py
+++ b/serpens/api.py
@@ -115,10 +115,13 @@ class Request:
 
 
 class Response:
-    def __init__(self, statusCode=200, body="", headers={"Access-Control-Allow-Origin": "*"}):
+    def __init__(self, statusCode=200, body="", headers=None):
         self.statusCode = statusCode
         self.body = body
-        self.headers = headers
+        self.headers = {"Access-Control-Allow-Origin": "*"}
+
+        if headers and isinstance(headers, dict):
+            self.headers.update(headers)
 
     def to_dict(self):
         return self.__dict__

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="serpens",
-    version="1.17.0",
+    version="1.17.1",
     description="A set of Python utilities, recipes and snippets",
     author="Everaldo Canuto",
     author_email="everaldo.canuto@gmail.com",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,6 +67,36 @@ class TestApiRequest(unittest.TestCase):
         self.assertEqual(instance.identity.sourceIp, "127.0.0.1")
 
 
+class TestApiResponse(unittest.TestCase):
+    def test_instance(self):
+        instance = api.Response(201, "Ok", {"Content-Type": "text/plain"})
+
+        self.assertIsInstance(instance, api.Response)
+        self.assertEqual(instance.statusCode, 201)
+        self.assertEqual(instance.body, "Ok")
+        self.assertDictEqual(
+            instance.headers, {"Content-Type": "text/plain", "Access-Control-Allow-Origin": "*"}
+        )
+
+    def test_to_dict(self):
+        expected = {"statusCode": 200, "body": "", "headers": {"Access-Control-Allow-Origin": "*"}}
+
+        instance = api.Response()
+
+        self.assertDictEqual(instance.to_dict(), expected)
+
+    def test_default_header(self):
+        first_response = api.Response()
+        first_response.headers["Foo"] = "Bar"
+
+        second_response = api.Response()
+
+        self.assertDictEqual(
+            first_response.headers, {"Access-Control-Allow-Origin": "*", "Foo": "Bar"}
+        )
+        self.assertDictEqual(second_response.headers, {"Access-Control-Allow-Origin": "*"})
+
+
 class TestApiHandler(unittest.TestCase):
     def test_handler(self):
         event = {


### PR DESCRIPTION
- Fix default header for API Response class instances.
- Add missing unit tests.