### PR TITLE
Rename secrets module

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage==6.2
-black==21.7b0
+black==22.3.0
 flake8==4.0.1
 
 boto3==1.20.26

--- a/serpens/envvars.py
+++ b/serpens/envvars.py
@@ -1,8 +1,7 @@
 import os
 import shlex
 
-from serpens import parameters
-from serpens import secrets
+from serpens import parameters, secrets_manager
 
 
 def get(key, default=None):
@@ -19,7 +18,7 @@ def get(key, default=None):
         tmp = result.split("://")[1].split("?")
         secret_name = tmp[0]
         secret_key = tmp[1] if len(tmp) > 1 else None
-        return secrets.get(secret_name, secret_key)
+        return secrets_manager.get(secret_name, secret_key)
 
     return result
 

--- a/serpens/secrets_manager.py
+++ b/serpens/secrets_manager.py
@@ -5,7 +5,7 @@ import boto3
 from serpens.cache import cached
 
 
-@cached("secrets", 900)
+@cached("secrets_manager", 900)
 def get(secret_id, keyname=None):
     client = boto3.client("secretsmanager")
 

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -65,7 +65,7 @@ class TestEnvVars(unittest.TestCase):
         os.environ["FOO"] = "parameters:///stored_parameter"
         self.assertEqual(envvars.get("FOO"), "stored_value")
 
-    @patch("envvars.secrets.get")
+    @patch("envvars.secrets_manager.get")
     def test_get_secrets(self, mock_secrets):
         mock_secrets.return_value = "stored_value"
 

--- a/tests/test_secrets_manager.py
+++ b/tests/test_secrets_manager.py
@@ -1,36 +1,37 @@
 import json
-import secrets
 import unittest
 from unittest.mock import patch
 
+import secrets_manager
 
-class TestSecrets(unittest.TestCase):
-    @patch("secrets.boto3")
+
+class TestSecretsManager(unittest.TestCase):
+    @patch("secrets_manager.boto3")
     def test_retrieve_secret_value_without_keyname(self, m_boto3):
         aws_response = {"SecretString": '{"key": "s3CrE7-V@1u3"}'}
         m_boto3.client.return_value.get_secret_value.return_value = aws_response
 
-        secret_value = secrets.get("Secret_Value")
+        secret_value = secrets_manager.get("Secret_Value")
 
         self.assertDictEqual(secret_value, json.loads(aws_response["SecretString"]))
         self.assertEqual(m_boto3.client.call_count, 1)
 
-    @patch("secrets.boto3")
+    @patch("secrets_manager.boto3")
     def test_retrieve_secret_value_with_invalid_json(self, m_boto3):
         aws_response = {"SecretString": "s3CrE7-V@1u3"}
         m_boto3.client.return_value.get_secret_value.return_value = aws_response
 
-        secret_value = secrets.get("Another_Secret_Value")
+        secret_value = secrets_manager.get("Another_Secret_Value")
 
         self.assertEqual(secret_value, aws_response["SecretString"])
         self.assertEqual(m_boto3.client.call_count, 1)
 
-    @patch("secrets.boto3")
+    @patch("secrets_manager.boto3")
     def test_retrieve_secret_value_with_keyname(self, m_boto3):
         aws_response = {"SecretString": '{"key": "s3CrE7-V@1u3"}'}
         m_boto3.client.return_value.get_secret_value.return_value = aws_response
 
-        secret_value = secrets.get("Another_Secret_Value", "key")
+        secret_value = secrets_manager.get("Another_Secret_Value", "key")
 
         self.assertEqual(secret_value, json.loads(aws_response["SecretString"])["key"])
         self.assertEqual(m_boto3.client.call_count, 1)


### PR DESCRIPTION
- Rename secrets module to secrets_manager to avoid conflicts with Python's core library