### PR TITLE
Feat/accept key with +55 and without

### DIFF
--- a/serpens/validators.py
+++ b/serpens/validators.py
@@ -89,7 +89,7 @@ def validate_pix(value: str) -> bool:
     if validate_email(value):
         return True
 
-    if value.startswith("+55") and validate_mobile_number(value.replace("+55", "")):
+    if validate_mobile_number(value.replace("+55", "")):
         return True
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="serpens",
-    version="2.0.0a7",
+    version="2.0.0a8",
     description="A set of Python utilities, recipes and snippets",
     author="Everaldo Canuto",
     author_email="everaldo.canuto@gmail.com",

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -84,6 +84,7 @@ class TestValidatePix(unittest.TestCase):
             "89930840000167",
             "user.name@domain.com",
             "+5594969161652",
+            "94969161652",
             "c3059309-a339-4585-9666-cc87749fd16b",
         )
         result = all(map(validators.validate_pix, values))


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Update test case to have phone_numer with +55 and without
* Accept phone number with +55 and without on validate_pix
* Bump setup version to 2.0.0a8