### PR TITLE
fix: base workflow reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   Publish:
-    uses: noverde/github-workflows/.github/workflows/publish_python_package@main
+    uses: noverde/github-workflows/.github/workflows/publish_python_package.yml@main
     secrets: inherit


### PR DESCRIPTION
Fix reference to base workflow on PyPI's publishing workflow.
