### PR TITLE
feat: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - open-pull-requests-limit: 10
+    package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "noverde/architecture"
+
+  - open-pull-requests-limit: 10
+    package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "noverde/architecture"


### PR DESCRIPTION
Enable Dependabot to promote updates via pull requests for both Python packages and GitHub Actions.
