### PR TITLE
feat: elastic sanitize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noverde-serpens"
-version = "2.1.0"
+version = "2.1.2"
 description = "A set of Python utilities, recipes and snippets"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noverde-serpens"
-version = "2.1.2"
+version = "2.1.0"
 description = "A set of Python utilities, recipes and snippets"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/serpens/elastic.py
+++ b/serpens/elastic.py
@@ -40,43 +40,15 @@ def set_transaction_result(result, override=True):
         elasticapm.set_transaction_result(result, override=override)
 
 
-def _setup_sanitize():
-    os.environ["ELASTIC_APM_PROCESSORS"] = (
-        "serpens.elastic_sanitize.sanitize,"
-        "elasticapm.processors.sanitize_stacktrace_locals,"
-        "elasticapm.processors.sanitize_http_request_cookies,"
-        "elasticapm.processors.sanitize_http_headers,"
-        "elasticapm.processors.sanitize_http_wsgi_env,"
-        "elasticapm.processors.sanitize_http_request_body"
-    )
-
-    if "ELASTIC_APM_SANITIZE_FIELD_NAMES" in os.environ:
-        field_names = os.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"]
-    else:
-        field_names = (
-            "password,"
-            "passwd,"
-            "pwd,"
-            "secret,"
-            "*key,"
-            "*token*,"
-            "*session*,"
-            "*credit*,"
-            "*card*,"
-            "*auth*,"
-            "set-cookie,"
-            "document,"
-            "cpf"
-        )
-
-    if "SERPENS_EXTRA_SANATIZE_FIELD_NAMES" in os.environ:
-        field_names = f"{field_names},{os.environ['SERPENS_EXTRA_SANATIZE_FIELD_NAMES']}"
-
-    os.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"] = field_names
-
-
 def setup():
     if "ELASTIC_APM_SECRET_TOKEN" in os.environ:
         os.environ["ELASTIC_APM_SECRET_TOKEN"] = envvars.get("ELASTIC_APM_SECRET_TOKEN")
 
-    _setup_sanitize()
+        os.environ["ELASTIC_APM_PROCESSORS"] = (
+            "serpens.elastic_sanitize.sanitize,"
+            "elasticapm.processors.sanitize_stacktrace_locals,"
+            "elasticapm.processors.sanitize_http_request_cookies,"
+            "elasticapm.processors.sanitize_http_headers,"
+            "elasticapm.processors.sanitize_http_wsgi_env,"
+            "elasticapm.processors.sanitize_http_request_body"
+        )

--- a/serpens/elastic.py
+++ b/serpens/elastic.py
@@ -40,6 +40,43 @@ def set_transaction_result(result, override=True):
         elasticapm.set_transaction_result(result, override=override)
 
 
+def _setup_sanitize():
+    os.environ["ELASTIC_APM_PROCESSORS"] = (
+        "serpens.elastic_sanitize.sanitize,"
+        "elasticapm.processors.sanitize_stacktrace_locals,"
+        "elasticapm.processors.sanitize_http_request_cookies,"
+        "elasticapm.processors.sanitize_http_headers,"
+        "elasticapm.processors.sanitize_http_wsgi_env,"
+        "elasticapm.processors.sanitize_http_request_body"
+    )
+
+    if "ELASTIC_APM_SANITIZE_FIELD_NAMES" in os.environ:
+        field_names = os.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"]
+    else:
+        field_names = (
+            "password,"
+            "passwd,"
+            "pwd,"
+            "secret,"
+            "*key,"
+            "*token*,"
+            "*session*,"
+            "*credit*,"
+            "*card*,"
+            "*auth*,"
+            "set-cookie,"
+            "document,"
+            "cpf"
+        )
+
+    if "SERPENS_EXTRA_SANATIZE_FIELD_NAMES" in os.environ:
+        field_names = f"{field_names},{os.environ['SERPENS_EXTRA_SANATIZE_FIELD_NAMES']}"
+
+    os.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"] = field_names
+
+
 def setup():
     if "ELASTIC_APM_SECRET_TOKEN" in os.environ:
         os.environ["ELASTIC_APM_SECRET_TOKEN"] = envvars.get("ELASTIC_APM_SECRET_TOKEN")
+
+    _setup_sanitize()

--- a/serpens/elastic_sanitize.py
+++ b/serpens/elastic_sanitize.py
@@ -1,0 +1,44 @@
+from elasticapm.conf.constants import ERROR, TRANSACTION
+from elasticapm.processors import for_events, BASE_SANITIZE_FIELD_NAMES, MASK, varmap
+
+
+def _sanitize_var(key, value, **kwargs):
+    # This function was copied from elasticapm.processors._sanitize
+
+    if "sanitize_field_names" in kwargs:
+        sanitize_field_names = kwargs["sanitize_field_names"]
+    else:
+        sanitize_field_names = BASE_SANITIZE_FIELD_NAMES
+
+    if value is None:
+        return
+
+    if isinstance(value, dict):
+        # varmap will call _sanitize on each k:v pair of the dict, so we don't
+        # have to do anything with dicts here
+        return value
+
+    if not key:  # key can be a NoneType
+        return value
+
+    key = key.lower()
+    for field in sanitize_field_names:
+        if field.match(key.strip()):
+            # store mask as a fixed length for security
+            return MASK
+
+    return value
+
+
+@for_events(ERROR, TRANSACTION)
+def sanitize(client, event):
+    body = event["context"]["request"]["body"]
+
+    if not isinstance(body, dict):
+        return event
+
+    event["context"]["request"]["body"] = varmap(
+        _sanitize_var, body, sanitize_field_names=client.config.sanitize_field_names
+    )
+
+    return event

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -1,8 +1,7 @@
-import os
 import unittest
 from unittest.mock import patch
 
-from serpens.elastic import logger, set_transaction_result
+from serpens.elastic import logger, set_transaction_result, _setup_sanitize
 
 
 class TestElastic(unittest.TestCase):
@@ -15,6 +14,10 @@ class TestElastic(unittest.TestCase):
         self.mock_elastic = self.elastic_patcher.start()
         self.m_capture_serverless = self.mock_elastic.capture_serverless
 
+        self.os_patcher = patch("serpens.elastic.os")
+        self.os_mock = self.os_patcher.start()
+        self.os_mock.environ = {}
+
     def tearDown(self):
         self.elastic_patcher.stop()
 
@@ -25,20 +28,50 @@ class TestElastic(unittest.TestCase):
         self.m_capture_serverless.assert_not_called()
 
     def test_logger_decorator_called(self):
-        os.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
+        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
         event, context = {}, {"key": "value"}
 
         logger(self.function)(event, context)
-        del os.environ["ELASTIC_APM_SECRET_TOKEN"]
         self.m_capture_serverless.assert_called_once()
         self.m_capture_serverless.assert_called_with(self.function)
 
     def test_set_transaction_result_with_elastic(self):
-        os.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
+        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
         set_transaction_result("Failure", False)
-        del os.environ["ELASTIC_APM_SECRET_TOKEN"]
         self.mock_elastic.set_transaction_result.assert_called_once_with("Failure", override=False)
 
     def test_set_transaction_result_without_elastic(self):
         set_transaction_result("Failure", False)
         self.mock_elastic.set_transaction_result.assert_not_called()
+
+    def test_setup_sanitize(self):
+        self.os_mock.environ["SERPENS_EXTRA_SANATIZE_FIELD_NAMES"] = "custom_attr"
+
+        _setup_sanitize()
+
+        field_names = (
+            "password,"
+            "passwd,"
+            "pwd,"
+            "secret,"
+            "*key,"
+            "*token*,"
+            "*session*,"
+            "*credit*,"
+            "*card*,"
+            "*auth*,"
+            "set-cookie,"
+            "document,"
+            "cpf,"
+            "custom_attr"
+        )
+
+        self.assertEqual(self.os_mock.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"], field_names)
+
+    def test_setup_sanitize_redefine_field_names(self):
+        field_names = "custom_attr"
+        self.os_mock.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"] = field_names
+
+        _setup_sanitize()
+
+        self.assertEqual(self.os_mock.environ["ELASTIC_APM_SANITIZE_FIELD_NAMES"], field_names)

--- a/tests/test_elastic_sanitize.py
+++ b/tests/test_elastic_sanitize.py
@@ -1,0 +1,98 @@
+from copy import deepcopy
+from elastic_sanitize import sanitize, _sanitize_var
+from elasticapm.base import Config
+from elasticapm.processors import MASK
+from elasticapm.utils import starmatch_to_regex
+import unittest
+
+
+class _ClientMock:
+    def __init__(self) -> None:
+        self.config = Config()
+
+
+class TestElasticSanitize(unittest.TestCase):
+    _client = _ClientMock()
+
+    def test_sanitize(self):
+        event = {
+            "context": {
+                "request": {
+                    "method": "POST",
+                    "body": {
+                        "sid": "27d52325-099f-4565-80d2-4ed64798c72c",
+                        "password": "654321",
+                        "partner_id": 1,
+                        "product_id": 3,
+                        "event": "payment.xpto",
+                        "url": "https://9574-168-205-69-207.sa.ngrok.io",
+                        "secret": "123456789",
+                        "data": {
+                            "payment_uuid": "27d52325-099f-4565-80d2-4ed64798c72c",
+                            "state": "created",
+                            "details": {
+                                "payment_slip_barcode": "1234567890",
+                                "payment_slip_digitable_line": "1234567890987654321",
+                                "password": "321312312",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        event_expected = deepcopy(event)
+        body_expected = event_expected["context"]["request"]["body"]
+        body_expected["password"] = MASK
+        body_expected["secret"] = MASK
+        body_expected["data"]["details"]["password"] = MASK
+
+        sanitize(self._client, event)
+
+        self.assertDictEqual(event_expected, event)
+
+    def test_sanitize_querystring(self):
+        event = {
+            "context": {
+                "request": {
+                    "method": "POST",
+                    "body": "test=test&password=32312",
+                },
+            },
+        }
+        event_expected = deepcopy(event)
+
+        sanitize(self._client, event)
+
+        self.assertDictEqual(event_expected, event)
+
+    def test_sanitize_var_mask(self):
+        fields_names_rules = ["*password*", "document"]
+        fields_names = [starmatch_to_regex(x) for x in fields_names_rules]
+
+        inputs = (
+            {"key": "pAsSwOrD", "value": "12345"},
+            {"key": "PASSWORD", "value": "12345"},
+            {"key": "PASSWORD_USER", "value": "12345", "sanitize_field_names": fields_names},
+            {"key": "DoCuMeNt", "value": "12345", "sanitize_field_names": fields_names},
+        )
+
+        for input in inputs:
+            with self.subTest(use_case=input):
+                value = _sanitize_var(**input)
+
+                self.assertEqual(value, MASK)
+
+    def test_sanitize_keep_value(self):
+        inputs = (
+            {"key": "custom", "value": "12345"},
+            {"key": None, "value": "12345"},
+            {"key": "PASSWORD", "value": None},
+            {"key": "PASSWORD", "value": {"PASSWORD": "12345"}},
+        )
+
+        for input in inputs:
+            with self.subTest(use_case=input):
+                previous_value = deepcopy(input["value"])
+                value = _sanitize_var(**input)
+
+                self.assertEqual(value, previous_value)


### PR DESCRIPTION
Add method to sanitize request body using JSON. The elasticapm.processors.sanitize_http_request_body method just sanitize Form URL encoded requests.