### PR TITLE
feat: add elastic capture response

### DIFF
--- a/serpens/api.py
+++ b/serpens/api.py
@@ -24,6 +24,8 @@ def handler(func):
             result = func(request)
 
             if isinstance(result, Response):
+                elastic.capture_response(result.body)
+
                 return result.to_dict()
 
             response = Response()
@@ -35,10 +37,13 @@ def handler(func):
             if is_dataclass(result):
                 result = asdict(result)
 
+            elastic.capture_response(result)
+
             if isinstance(result, (dict, list)):
                 result = json.dumps(result, cls=SchemaEncoder)
 
             response.body = result
+
             return response.to_dict()
         except Exception as ex:
             logger_exception(ex)

--- a/serpens/elastic.py
+++ b/serpens/elastic.py
@@ -1,21 +1,31 @@
+import json
+import logging
 import sys
 import os
-import logging
 from functools import wraps
+from schema import SchemaEncoder
 from serpens import envvars
 
 logger = logging.getLogger(__name__)
 
+_response_sanitize_fields = []
+
 try:
     import elasticapm
+    from elasticapm.utils import starmatch_to_regex
+    from elastic_sanitize import sanitize_body
 except ImportError:
     logger.warning("Unable to import elasticapm")
+
+
+def elastic_enabled():
+    return "ELASTIC_APM_SECRET_TOKEN" in os.environ
 
 
 def logger(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if "ELASTIC_APM_SECRET_TOKEN" in os.environ:
+        if elastic_enabled():
             return elasticapm.capture_serverless(func)(*args, **kwargs)
         return func(*args, **kwargs)
 
@@ -23,7 +33,7 @@ def logger(func):
 
 
 def capture_exception(exception, is_http_request=False):
-    if "ELASTIC_APM_SECRET_TOKEN" in os.environ:
+    if elastic_enabled():
         elasticapm.get_client().capture_exception(exc_info=sys.exc_info(), handled=False)
 
         if is_http_request:
@@ -35,20 +45,62 @@ def capture_exception(exception, is_http_request=False):
             elasticapm.set_transaction_outcome(outcome="failure", override=False)
 
 
+def capture_response(response):
+    if not elastic_enabled():
+        return None
+
+    if isinstance(response, str) and (response[0] == "{" or response[0] == "["):
+        try:
+            response = json.loads(response)
+        except ValueError:
+            pass
+
+    if not isinstance(response, (dict, list)):
+        return None
+
+    response_body = json.dumps(
+        sanitize_body(response, _response_sanitize_fields), cls=SchemaEncoder
+    )
+    elasticapm.set_custom_context({"response_body": response_body})
+
+
 def set_transaction_result(result, override=True):
-    if "ELASTIC_APM_SECRET_TOKEN" in os.environ:
+    if elastic_enabled():
         elasticapm.set_transaction_result(result, override=override)
 
 
 def setup():
-    if "ELASTIC_APM_SECRET_TOKEN" in os.environ:
-        os.environ["ELASTIC_APM_SECRET_TOKEN"] = envvars.get("ELASTIC_APM_SECRET_TOKEN")
+    global _response_sanitize_fields
 
-        os.environ["ELASTIC_APM_PROCESSORS"] = (
-            "serpens.elastic_sanitize.sanitize,"
-            "elasticapm.processors.sanitize_stacktrace_locals,"
-            "elasticapm.processors.sanitize_http_request_cookies,"
-            "elasticapm.processors.sanitize_http_headers,"
-            "elasticapm.processors.sanitize_http_wsgi_env,"
-            "elasticapm.processors.sanitize_http_request_body"
+    if not elastic_enabled():
+        return None
+
+    os.environ["ELASTIC_APM_SECRET_TOKEN"] = envvars.get("ELASTIC_APM_SECRET_TOKEN")
+
+    os.environ["ELASTIC_APM_PROCESSORS"] = (
+        "serpens.elastic_sanitize.sanitize,"
+        "elasticapm.processors.sanitize_stacktrace_locals,"
+        "elasticapm.processors.sanitize_http_request_cookies,"
+        "elasticapm.processors.sanitize_http_headers,"
+        "elasticapm.processors.sanitize_http_wsgi_env,"
+        "elasticapm.processors.sanitize_http_request_body"
+    )
+
+    sanitize_field_names = None
+    if "SERPENS_RESPONSE_SANITIZE_FIELD_NAMES" in os.environ:
+        sanitize_field_names = os.environ["SERPENS_RESPONSE_SANITIZE_FIELD_NAMES"].split(",")
+    else:
+        sanitize_field_names = (
+            "password",
+            "passwd",
+            "pwd",
+            "secret",
+            "*key",
+            "*token*",
+            "*session*",
+            "*credit*",
+            "*card*",
+            "*auth*",
         )
+
+    _response_sanitize_fields = [starmatch_to_regex(x) for x in sanitize_field_names]

--- a/serpens/elastic.py
+++ b/serpens/elastic.py
@@ -3,94 +3,27 @@ import logging
 import sys
 import os
 from functools import wraps
-from schema import SchemaEncoder
-from serpens import envvars
+from serpens.schema import SchemaEncoder
 
 logger = logging.getLogger(__name__)
-
-_response_sanitize_fields = []
 
 try:
     import elasticapm
     from elasticapm.utils import starmatch_to_regex
-    from elastic_sanitize import sanitize_body
+    from elasticapm.processors import MASK, varmap
 except ImportError:
     logger.warning("Unable to import elasticapm")
 
 
-def elastic_enabled():
-    return "ELASTIC_APM_SECRET_TOKEN" in os.environ
-
-
-def logger(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if elastic_enabled():
-            return elasticapm.capture_serverless(func)(*args, **kwargs)
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-def capture_exception(exception, is_http_request=False):
-    if elastic_enabled():
-        elasticapm.get_client().capture_exception(exc_info=sys.exc_info(), handled=False)
-
-        if is_http_request:
-            elasticapm.set_transaction_result("HTTP 5xx", override=False)
-            elasticapm.set_transaction_outcome(http_status_code=500, override=False)
-            elasticapm.set_context({"status_code": 500}, "response")
-        else:
-            elasticapm.set_transaction_result("failure", override=False)
-            elasticapm.set_transaction_outcome(outcome="failure", override=False)
-
-
-def capture_response(response):
-    if not elastic_enabled():
+def _get_response_sanitize_fields(enabled):
+    if not enabled:
         return None
 
-    if isinstance(response, str) and (response[0] == "{" or response[0] == "["):
-        try:
-            response = json.loads(response)
-        except ValueError:
-            pass
-
-    if not isinstance(response, (dict, list)):
-        return None
-
-    response_body = json.dumps(
-        sanitize_body(response, _response_sanitize_fields), cls=SchemaEncoder
-    )
-    elasticapm.set_custom_context({"response_body": response_body})
-
-
-def set_transaction_result(result, override=True):
-    if elastic_enabled():
-        elasticapm.set_transaction_result(result, override=override)
-
-
-def setup():
-    global _response_sanitize_fields
-
-    if not elastic_enabled():
-        return None
-
-    os.environ["ELASTIC_APM_SECRET_TOKEN"] = envvars.get("ELASTIC_APM_SECRET_TOKEN")
-
-    os.environ["ELASTIC_APM_PROCESSORS"] = (
-        "serpens.elastic_sanitize.sanitize,"
-        "elasticapm.processors.sanitize_stacktrace_locals,"
-        "elasticapm.processors.sanitize_http_request_cookies,"
-        "elasticapm.processors.sanitize_http_headers,"
-        "elasticapm.processors.sanitize_http_wsgi_env,"
-        "elasticapm.processors.sanitize_http_request_body"
-    )
-
-    sanitize_field_names = None
-    if "SERPENS_RESPONSE_SANITIZE_FIELD_NAMES" in os.environ:
-        sanitize_field_names = os.environ["SERPENS_RESPONSE_SANITIZE_FIELD_NAMES"].split(",")
+    field_names = None
+    if "ELASTIC_APM_RESPONSE_SANITIZE_FIELD_NAMES" in os.environ:
+        field_names = os.environ["ELASTIC_APM_RESPONSE_SANITIZE_FIELD_NAMES"].split(",")
     else:
-        sanitize_field_names = (
+        field_names = (
             "password",
             "passwd",
             "pwd",
@@ -103,4 +36,89 @@ def setup():
             "*auth*",
         )
 
-    _response_sanitize_fields = [starmatch_to_regex(x) for x in sanitize_field_names]
+    return [starmatch_to_regex(x) for x in field_names]
+
+
+ELASTIC_APM_ENABLED = "ELASTIC_APM_SECRET_TOKEN" in os.environ
+
+ELASTIC_APM_RESPONSE_SANITIZE_FIELDS = _get_response_sanitize_fields(ELASTIC_APM_ENABLED)
+
+
+def logger(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if ELASTIC_APM_ENABLED:
+            return elasticapm.capture_serverless(func)(*args, **kwargs)
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def capture_exception(exception, is_http_request=False):
+    if not ELASTIC_APM_ENABLED:
+        return None
+
+    elasticapm.get_client().capture_exception(exc_info=sys.exc_info(), handled=False)
+
+    if is_http_request:
+        elasticapm.set_transaction_result("HTTP 5xx", override=False)
+        elasticapm.set_transaction_outcome(http_status_code=500, override=False)
+        elasticapm.set_context({"status_code": 500}, "response")
+    else:
+        elasticapm.set_transaction_result("failure", override=False)
+        elasticapm.set_transaction_outcome(outcome="failure", override=False)
+
+
+def _sanitize_var(key, value, sanitize_field_names):
+    if value is None:
+        return None
+
+    if not key or isinstance(value, dict):
+        return value
+
+    key = key.lower().strip()
+    for field in sanitize_field_names:
+        if field.match(key):
+            return MASK
+
+    return value
+
+
+def capture_response(response):
+    if not ELASTIC_APM_ENABLED:
+        return None
+
+    if isinstance(response, str):
+        try:
+            response = json.loads(response)
+        except json.JSONDecodeError:
+            return None
+
+    if not isinstance(response, (dict, list)):
+        return None
+
+    response_body = json.dumps(
+        varmap(_sanitize_var, response, sanitize_field_names=ELASTIC_APM_RESPONSE_SANITIZE_FIELDS),
+        cls=SchemaEncoder,
+    )
+    elasticapm.set_custom_context({"response_body": response_body})
+
+
+def set_transaction_result(result, override=True):
+    if ELASTIC_APM_ENABLED:
+        elasticapm.set_transaction_result(result, override=override)
+
+
+def setup():
+    if not ELASTIC_APM_ENABLED:
+        return None
+
+    os.environ["ELASTIC_APM_PROCESSORS"] = (
+        "serpens.elastic_sanitize.sanitize,"
+        "elasticapm.processors.sanitize_stacktrace_locals,"
+        "elasticapm.processors.sanitize_http_request_cookies,"
+        "elasticapm.processors.sanitize_http_headers,"
+        "elasticapm.processors.sanitize_http_wsgi_env,"
+        "elasticapm.processors.sanitize_http_request_body"
+    )

--- a/serpens/elastic_sanitize.py
+++ b/serpens/elastic_sanitize.py
@@ -17,6 +17,10 @@ def _sanitize_var(key, value, sanitize_field_names):
     return value
 
 
+def sanitize_body(body, sanitize_fields):
+    return varmap(_sanitize_var, body, sanitize_field_names=sanitize_fields)
+
+
 @for_events(ERROR, TRANSACTION)
 def sanitize(client, event):
     body = None

--- a/serpens/elastic_sanitize.py
+++ b/serpens/elastic_sanitize.py
@@ -17,10 +17,6 @@ def _sanitize_var(key, value, sanitize_field_names):
     return value
 
 
-def sanitize_body(body, sanitize_fields):
-    return varmap(_sanitize_var, body, sanitize_field_names=sanitize_fields)
-
-
 @for_events(ERROR, TRANSACTION)
 def sanitize(client, event):
     body = None

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -1,10 +1,10 @@
 from elasticapm.processors import MASK
-from elasticapm.utils import starmatch_to_regex
 from serpens import elastic
-from serpens.elastic import logger, set_transaction_result, setup, capture_response
+from serpens.elastic import logger, set_transaction_result
 from unittest.mock import patch
 import json
 import unittest
+from elasticapm.utils import starmatch_to_regex
 
 
 class TestElastic(unittest.TestCase):
@@ -21,9 +21,15 @@ class TestElastic(unittest.TestCase):
         self.os_mock = self.os_patcher.start()
         self.os_mock.environ = {}
 
+        target = "serpens.elastic.ELASTIC_APM_RESPONSE_SANITIZE_FIELDS"
+        value = elastic._get_response_sanitize_fields(True)
+        self.os_sanitize_fields = patch(target, value)
+        self.os_sanitize_fields.start()
+
     def tearDown(self):
         self.elastic_patcher.stop()
         self.os_patcher.stop()
+        self.os_sanitize_fields.stop()
 
     def test_logger_decorator_not_called(self):
         event, context = {}, {}
@@ -31,16 +37,16 @@ class TestElastic(unittest.TestCase):
         logger(self.function)(event, context)
         self.m_capture_serverless.assert_not_called()
 
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     def test_logger_decorator_called(self):
-        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
         event, context = {}, {"key": "value"}
 
         logger(self.function)(event, context)
         self.m_capture_serverless.assert_called_once()
         self.m_capture_serverless.assert_called_with(self.function)
 
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     def test_set_transaction_result_with_elastic(self):
-        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
         set_transaction_result("Failure", False)
         self.mock_elastic.set_transaction_result.assert_called_once_with("Failure", override=False)
 
@@ -48,22 +54,17 @@ class TestElastic(unittest.TestCase):
         set_transaction_result("Failure", False)
         self.mock_elastic.set_transaction_result.assert_not_called()
 
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     def test_setup(self):
-        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
-        self.os_mock.environ["SERPENS_RESPONSE_SANITIZE_FIELD_NAMES"] = "password,passwd"
-        setup()
+        elastic.setup()
 
         apm_processors = self.os_mock.environ.get("ELASTIC_APM_PROCESSORS")
 
         self.assertIsNotNone(apm_processors)
         self.assertTrue("serpens.elastic_sanitize.sanitize" in apm_processors)
-        expected_fieds = [starmatch_to_regex(x) for x in ("password", "passwd")]
-        self.assertEqual(elastic._response_sanitize_fields, expected_fieds)
 
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     def test_capture_response_string(self):
-        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
-        setup()
-
         bodies = [
             "Test body.",
             "[]Test body.",
@@ -71,30 +72,36 @@ class TestElastic(unittest.TestCase):
         ]
 
         for body in bodies:
-            capture_response(body)
+            elastic.capture_response(body)
             self.mock_elastic.set_custom_context.assert_not_called()
 
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     def test_capture_response_json_string(self):
-        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
-        setup()
-
         body = '{"name":"Test", "password":12345}'
         expected = json.dumps({"name": "Test", "password": MASK})
 
-        capture_response(body)
+        elastic.capture_response(body)
         self.mock_elastic.set_custom_context.assert_called_once_with({"response_body": expected})
 
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     def test_capture_response(self):
-        self.os_mock.environ["ELASTIC_APM_SECRET_TOKEN"] = "123456"
-        setup()
-
         body = {"name": "Test", "password": 12345}
         expected = json.dumps({"name": "Test", "password": MASK})
 
-        capture_response(body)
+        elastic.capture_response(body)
         self.mock_elastic.set_custom_context.assert_called_once_with({"response_body": expected})
 
     def test_capture_response_disabled(self):
         body = {"name": "Test", "password": 12345}
-        capture_response(body)
+        elastic.capture_response(body)
         self.mock_elastic.set_custom_context.assert_not_called()
+
+    def test_get_response_sanitize_field_names(self):
+        self.os_mock.environ["ELASTIC_APM_RESPONSE_SANITIZE_FIELD_NAMES"] = "password,passwd"
+        field_names = ("password", "passwd")
+
+        fields_expected = [starmatch_to_regex(x) for x in field_names]
+
+        fields = elastic._get_response_sanitize_fields(True)
+
+        self.assertEqual(fields, fields_expected)

--- a/tests/test_elastic_sanitize.py
+++ b/tests/test_elastic_sanitize.py
@@ -1,8 +1,10 @@
 from copy import deepcopy
-from elastic_sanitize import sanitize, _sanitize_var
+from elastic_sanitize import sanitize_http_request_body, sanitize_http_response_body, _sanitize_var
 from elasticapm.base import Config
 from elasticapm.processors import MASK
 from elasticapm.utils import starmatch_to_regex
+from serpens.schema import SchemaEncoder
+import json
 import unittest
 
 
@@ -14,39 +16,21 @@ class _ClientMock:
 class TestElasticSanitize(unittest.TestCase):
     _client = _ClientMock()
 
-    def test_sanitize(self):
+    def test_sanitize_http_request_body(self):
+        body, body_expected = self._get_sanitize_transform()
+
         event = {
             "context": {
                 "request": {
                     "method": "POST",
-                    "body": {
-                        "sid": "27d52325-099f-4565-80d2-4ed64798c72c",
-                        "password": "654321",
-                        "partner_id": 1,
-                        "product_id": 3,
-                        "event": "payment.xpto",
-                        "url": "https://9574-168-205-69-207.sa.ngrok.io",
-                        "secret": "123456789",
-                        "data": {
-                            "payment_uuid": "27d52325-099f-4565-80d2-4ed64798c72c",
-                            "state": "created",
-                            "details": {
-                                "payment_slip_barcode": "1234567890",
-                                "payment_slip_digitable_line": "1234567890987654321",
-                                "password": "321312312",
-                            },
-                        },
-                    },
+                    "body": body,
                 },
             },
         }
         event_expected = deepcopy(event)
-        body_expected = event_expected["context"]["request"]["body"]
-        body_expected["password"] = MASK
-        body_expected["secret"] = MASK
-        body_expected["data"]["details"]["password"] = MASK
+        event_expected["context"]["request"]["body"] = body_expected
 
-        sanitize(self._client, event)
+        sanitize_http_request_body(self._client, event)
 
         self.assertDictEqual(event_expected, event)
 
@@ -65,7 +49,7 @@ class TestElasticSanitize(unittest.TestCase):
         for event in events:
             with self.subTest(use_case=event):
                 event_expected = deepcopy(event)
-                sanitize(self._client, event)
+                sanitize_http_request_body(self._client, event)
 
                 self.assertDictEqual(event_expected, event)
 
@@ -105,3 +89,105 @@ class TestElasticSanitize(unittest.TestCase):
                 value = _sanitize_var(**input)
 
                 self.assertEqual(value, previous_value)
+
+    def test_sanitize_http_response_body(self):
+        body, body_expected = self._get_sanitize_transform()
+
+        events = [
+            {
+                "context": {
+                    "custom": {
+                        "response_body": body,
+                    },
+                },
+            },
+            {
+                "context": {
+                    "custom": {
+                        "response_body": json.dumps(body, cls=SchemaEncoder),
+                    },
+                },
+            },
+        ]
+
+        for event in events:
+            event_expected = deepcopy(event)
+            event_expected["context"]["custom"]["response_body"] = json.dumps(
+                body_expected, cls=SchemaEncoder
+            )
+
+            sanitize_http_response_body(self._client, event)
+
+            self.assertDictEqual(event_expected, event)
+
+    def test_sanitize_http_response_body_list(self):
+        body, body_expected = self._get_sanitize_transform()
+
+        event = {
+            "context": {
+                "custom": {
+                    "response_body": [body, body],
+                },
+            },
+        }
+        event_expected = deepcopy(event)
+        event_expected["context"]["custom"]["response_body"] = json.dumps(
+            [body_expected, body_expected], cls=SchemaEncoder
+        )
+
+        sanitize_http_response_body(self._client, event)
+
+        self.assertDictEqual(event_expected, event)
+
+    def test_sanitize_http_response_body_string(self):
+        events = [
+            {
+                "context": {
+                    "custom": {
+                        "response_body": "foo=bar&ping=pong",
+                    },
+                },
+            },
+            {
+                "context": {
+                    "custom": {
+                        "response_body": '"foo=bar&ping=pong"',
+                    },
+                },
+            },
+        ]
+
+        for event in events:
+            event_expected = deepcopy(event)
+            event_expected["context"]["custom"].pop("response_body")
+
+            sanitize_http_response_body(self._client, event)
+
+            self.assertDictEqual(event_expected, event)
+
+    def _get_sanitize_transform(self):
+        body = {
+            "sid": "27d52325-099f-4565-80d2-4ed64798c72c",
+            "password": "654321",
+            "partner_id": 1,
+            "product_id": 3,
+            "event": "payment.xpto",
+            "url": "https://9574-168-205-69-207.sa.ngrok.io",
+            "secret": "123456789",
+            "data": {
+                "payment_uuid": "27d52325-099f-4565-80d2-4ed64798c72c",
+                "state": "created",
+                "details": {
+                    "payment_slip_barcode": "1234567890",
+                    "payment_slip_digitable_line": "1234567890987654321",
+                    "password": "321312312",
+                },
+            },
+        }
+
+        body_expected = deepcopy(body)
+        body_expected["password"] = MASK
+        body_expected["secret"] = MASK
+        body_expected["data"]["details"]["password"] = MASK
+
+        return body, body_expected

--- a/tests/test_elastic_sanitize.py
+++ b/tests/test_elastic_sanitize.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from elastic_sanitize import sanitize, _sanitize_var, sanitize_body
+from elastic_sanitize import sanitize, _sanitize_var
 from elasticapm.base import Config
 from elasticapm.processors import MASK
 from elasticapm.utils import starmatch_to_regex
@@ -105,24 +105,3 @@ class TestElasticSanitize(unittest.TestCase):
                 value = _sanitize_var(**input)
 
                 self.assertEqual(value, previous_value)
-
-    def test_sanitize_body(self):
-        sanitize_field_names = ("password", "passwd")
-
-        sanitize_fields = [starmatch_to_regex(x) for x in sanitize_field_names]
-
-        body = {"name": "Max Fitch", "password": 1235, "passwd": "1234"}
-        expected = {"name": "Max Fitch", "password": MASK, "passwd": MASK}
-
-        items = [
-            {
-                "body": body,
-                "expected": expected,
-            },
-            {"body": [body, body], "expected": [expected, expected]},
-        ]
-
-        for item in items:
-            with self.subTest(use_case=item):
-                sanitized = sanitize_body(item["body"], sanitize_fields)
-                self.assertEqual(sanitized, item["expected"])


### PR DESCRIPTION
Added a method to standardize response body storage in Elastic APM. This method hides personal data fields.
The list of personal data fields can be modified using the ELASTIC_APM_SANITIZE_FIELD_NAMES environment variable.