### PR TITLE
feat: changed Elastic APM request body to string

### DIFF
--- a/serpens/elastic.py
+++ b/serpens/elastic.py
@@ -53,15 +53,16 @@ def set_transaction_result(result, override=True):
 
 
 def setup():
-    if not ELASTIC_APM_ENABLED:
+    if not ELASTIC_APM_ENABLED or not ELASTIC_APM_CAPTURE_BODY:
         return None
 
-    os.environ["ELASTIC_APM_PROCESSORS"] = (
-        "serpens.elastic_sanitize.sanitize_http_request_body,"
-        "serpens.elastic_sanitize.sanitize_http_response_body,"
-        "elasticapm.processors.sanitize_stacktrace_locals,"
-        "elasticapm.processors.sanitize_http_request_cookies,"
-        "elasticapm.processors.sanitize_http_headers,"
-        "elasticapm.processors.sanitize_http_wsgi_env,"
-        "elasticapm.processors.sanitize_http_request_body"
-    )
+    if "ELASTIC_APM_PROCESSORS" not in os.environ:
+        os.environ["ELASTIC_APM_PROCESSORS"] = (
+            "serpens.elastic_sanitize.sanitize_http_request_body,"
+            "serpens.elastic_sanitize.sanitize_http_response_body,"
+            "elasticapm.processors.sanitize_stacktrace_locals,"
+            "elasticapm.processors.sanitize_http_request_cookies,"
+            "elasticapm.processors.sanitize_http_headers,"
+            "elasticapm.processors.sanitize_http_wsgi_env,"
+            "elasticapm.processors.sanitize_http_request_body"
+        )

--- a/serpens/elastic_sanitize.py
+++ b/serpens/elastic_sanitize.py
@@ -29,9 +29,8 @@ def sanitize_http_request_body(client, event):
     if not isinstance(body, (dict, list)):
         return event
 
-    event["context"]["request"]["body"] = varmap(
-        _sanitize_var, body, sanitize_field_names=client.config.sanitize_field_names
-    )
+    body = varmap(_sanitize_var, body, sanitize_field_names=client.config.sanitize_field_names)
+    event["context"]["request"]["body"] = json.dumps(body, cls=SchemaEncoder)
 
     return event
 

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -5,6 +5,9 @@ import unittest
 
 
 class TestElastic(unittest.TestCase):
+    def _getenv(self, key, default=None):
+        return self.os_mock.environ.get(key, default)
+
     def setUp(self):
         def to_be_decorated(event, context, **kwargs):
             pass
@@ -17,6 +20,7 @@ class TestElastic(unittest.TestCase):
         self.os_patcher = patch("serpens.elastic.os")
         self.os_mock = self.os_patcher.start()
         self.os_mock.environ = {}
+        self.os_mock.getenv = self._getenv
 
     def tearDown(self):
         self.elastic_patcher.stop()
@@ -46,14 +50,33 @@ class TestElastic(unittest.TestCase):
         self.mock_elastic.set_transaction_result.assert_not_called()
 
     @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
+    @patch("serpens.elastic.ELASTIC_APM_CAPTURE_BODY", True)
     def test_setup(self):
         elastic.setup()
 
-        apm_processors = self.os_mock.environ.get("ELASTIC_APM_PROCESSORS")
+        processors = self.os_mock.environ.get("ELASTIC_APM_PROCESSORS")
 
-        self.assertIsNotNone(apm_processors)
-        self.assertTrue("serpens.elastic_sanitize.sanitize_http_request_body" in apm_processors)
-        self.assertTrue("serpens.elastic_sanitize.sanitize_http_response_body" in apm_processors)
+        processors_expected = (
+            "serpens.elastic_sanitize.sanitize_http_request_body,"
+            "serpens.elastic_sanitize.sanitize_http_response_body,"
+            "elasticapm.processors.sanitize_stacktrace_locals,"
+            "elasticapm.processors.sanitize_http_request_cookies,"
+            "elasticapm.processors.sanitize_http_headers,"
+            "elasticapm.processors.sanitize_http_wsgi_env,"
+            "elasticapm.processors.sanitize_http_request_body"
+        )
+
+        self.assertEqual(processors, processors_expected)
+
+    @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
+    @patch("serpens.elastic.ELASTIC_APM_CAPTURE_BODY", True)
+    def test_setup_with_processors(self):
+        processors = "elasticapm.processors.sanitize_http_headers"
+        self.os_mock.environ["ELASTIC_APM_PROCESSORS"] = processors
+
+        elastic.setup()
+
+        self.assertEqual(self.os_mock.environ["ELASTIC_APM_PROCESSORS"], processors)
 
     @patch("serpens.elastic.ELASTIC_APM_ENABLED", True)
     @patch("serpens.elastic.ELASTIC_APM_CAPTURE_BODY", True)

--- a/tests/test_elastic_sanitize.py
+++ b/tests/test_elastic_sanitize.py
@@ -28,7 +28,7 @@ class TestElasticSanitize(unittest.TestCase):
             },
         }
         event_expected = deepcopy(event)
-        event_expected["context"]["request"]["body"] = body_expected
+        event_expected["context"]["request"]["body"] = json.dumps(body_expected, cls=SchemaEncoder)
 
         sanitize_http_request_body(self._client, event)
 
@@ -46,7 +46,8 @@ class TestElasticSanitize(unittest.TestCase):
             },
         }
         event_expected = deepcopy(event)
-        event_expected["context"]["request"]["body"] = [body_expected, body_expected]
+        body_expected = json.dumps([body_expected, body_expected], cls=SchemaEncoder)
+        event_expected["context"]["request"]["body"] = body_expected
 
         sanitize_http_request_body(self._client, event)
 


### PR DESCRIPTION
- Elastic APM request body changed to string. This is required for list-type request bodies to be compatible with ELK.
- Added check to only set ELASTIC_APM_PROCESSORS if this environment variable is not set. This makes it possible to disable the ELK's default processors.