### PR TITLE
fix: simplified logger exception call in the API module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noverde-serpens"
-version = "2.3.0"
+version = "2.3.1"
 description = "A set of Python utilities, recipes and snippets"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/serpens/api.py
+++ b/serpens/api.py
@@ -5,7 +5,6 @@ from functools import wraps
 
 from serpens import initializers, elastic
 from serpens.schema import SchemaEncoder
-from serpens.sentry import logger_exception
 
 
 initializers.setup()
@@ -46,7 +45,7 @@ def handler(func):
 
             return response.to_dict()
         except Exception as ex:
-            logger_exception(ex)
+            logger.exception(ex)
             elastic.capture_exception(ex, is_http_request=True)
             return {
                 "statusCode": 500,


### PR DESCRIPTION
Simplified logger exception call in the API module, because the logger_exception method in the sentry module was deprecated. The manual flush Sentry is not good way to prevent lose logs.