### PR TITLE
fix: name validation to match one character that is not a non-word character

### DIFF
--- a/serpens/validators.py
+++ b/serpens/validators.py
@@ -103,5 +103,5 @@ def validate_pix(value: str) -> bool:
 
 
 def validate_name(name: str) -> bool:
-    match = re.match(r"^[^\d\W]{2}[\w.'\- ]{0,78}$", name)
+    match = re.match(r"^[^\d\W]{1}[\w.'\- ]{0,78}$", name)
     return match is not None

--- a/serpens/validators.py
+++ b/serpens/validators.py
@@ -103,5 +103,5 @@ def validate_pix(value: str) -> bool:
 
 
 def validate_name(name: str) -> bool:
-    match = re.match(r"^[^\d\W]{1}[\w.'\- ]{0,78}$", name)
+    match = re.match(r"^[^\d\W]{1}[\w.'\- ]{0,79}$", name)
     return match is not None

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -132,6 +132,7 @@ class TestValidateName(unittest.TestCase):
             "Marcos Assunção",
             "Maria da Silva e Silva",
             "Juscelino Kubitschek de Oliveira",
+            "D'Artagnan",
         )
         for name in names:
             with self.subTest(msg=name):
@@ -146,7 +147,7 @@ class TestValidateName(unittest.TestCase):
             "0Chao Chang",
             " Chao Chang",
             "## Chao Chang",
-            "Æ Chao Chang",
+            "$ Chao Chang",
         )
 
         for name in names:


### PR DESCRIPTION
- Fix name validation to match one character that is not a non-word character, in order to let names like "D'Artagnan" pass the validation