### PR TITLE
fix: check if ordering key is None

### DIFF
--- a/serpens/pubsub.py
+++ b/serpens/pubsub.py
@@ -19,6 +19,9 @@ def publish_message(
     if attributes is None:
         attributes = {}
 
+    if ordering_key is None:
+        ordering_key = ""
+
     if ":" in topic:
         topic, endpoint = topic.split(":")
         attributes["endpoint"] = endpoint


### PR DESCRIPTION
In MessageClient we defined order_key with None default value, which cause an error in pub sub that expect "" if not provided ordering.