### PR TITLE
fix: update publisher client options to enable ordering messages

### DIFF
--- a/serpens/pubsub.py
+++ b/serpens/pubsub.py
@@ -14,7 +14,7 @@ def publish_message(
     ordering_key: str = "",
     attributes: Optional[Dict[str, Any]] = None,
 ) -> str:
-    publisher_options = pubsub_v1.types.PublisherOptions(enable_message_ordering=True)
+    publisher_options = pubsub_v1.types.PublisherOptions(enable_message_ordering=bool(ordering_key))
     publisher = pubsub_v1.PublisherClient(publisher_options=publisher_options)
 
     if not isinstance(data, str):
@@ -41,7 +41,7 @@ def publish_message(
 
 
 def publish_message_batch(topic: str, messages: List[Dict], ordering_key: str = "") -> List[str]:
-    publisher_options = pubsub_v1.types.PublisherOptions(enable_message_ordering=True)
+    publisher_options = pubsub_v1.types.PublisherOptions(enable_message_ordering=bool(ordering_key))
     batch_settings = pubsub_v1.types.BatchSettings(max_messages=MAX_BATCH_SIZE)
     publisher = pubsub_v1.PublisherClient(
         batch_settings=batch_settings, publisher_options=publisher_options

--- a/serpens/pubsub.py
+++ b/serpens/pubsub.py
@@ -14,7 +14,8 @@ def publish_message(
     ordering_key: str = "",
     attributes: Optional[Dict[str, Any]] = None,
 ) -> str:
-    publisher = pubsub_v1.PublisherClient()
+    publisher_options = pubsub_v1.types.PublisherOptions(enable_message_ordering=True)
+    publisher = pubsub_v1.PublisherClient(publisher_options=publisher_options)
 
     if not isinstance(data, str):
         data = json.dumps(data, cls=SchemaEncoder)
@@ -40,8 +41,11 @@ def publish_message(
 
 
 def publish_message_batch(topic: str, messages: List[Dict], ordering_key: str = "") -> List[str]:
+    publisher_options = pubsub_v1.types.PublisherOptions(enable_message_ordering=True)
     batch_settings = pubsub_v1.types.BatchSettings(max_messages=MAX_BATCH_SIZE)
-    publisher = pubsub_v1.PublisherClient(batch_settings=batch_settings)
+    publisher = pubsub_v1.PublisherClient(
+        batch_settings=batch_settings, publisher_options=publisher_options
+    )
 
     futures = []
     endpoint = None


### PR DESCRIPTION
### Contain
- [x] Bugfix

### Details
* Update publisher client options to enable ordering messages

### Task
[Task 151538](https://dotzmkt.visualstudio.com/Arquitetura/_workitems/edit/151538): Criar função para públicar mensagens em lote