### PR TITLE
fix(database): split SET stmts for asyncpg (2.8.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noverde-serpens"
-version = "2.8.0"
+version = "2.8.1"
 description = "A set of Python utilities, recipes and snippets"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/serpens/database/__init__.py
+++ b/serpens/database/__init__.py
@@ -52,11 +52,9 @@ def _on_connect(dbapi_conn, _):
     idle_ms = int(os.getenv("DB_IDLE_IN_TX_TIMEOUT_MS", "10000"))
     cur = dbapi_conn.cursor()
     try:
-        cur.execute(
-            f"SET statement_timeout = {stmt_ms};"
-            f"SET lock_timeout = {lock_ms};"
-            f"SET idle_in_transaction_session_timeout = {idle_ms}"
-        )
+        cur.execute(f"SET statement_timeout = {stmt_ms}")
+        cur.execute(f"SET lock_timeout = {lock_ms}")
+        cur.execute(f"SET idle_in_transaction_session_timeout = {idle_ms}")
     finally:
         cur.close()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -177,10 +177,11 @@ class TestOnConnect(unittest.TestCase):
             },
         ):
             database._on_connect(conn, None)
-        called_sql = cur.execute.call_args.args[0]
-        self.assertIn("statement_timeout = 9000", called_sql)
-        self.assertIn("lock_timeout = 1500", called_sql)
-        self.assertIn("idle_in_transaction_session_timeout = 12000", called_sql)
+        executed = [c.args[0] for c in cur.execute.call_args_list]
+        self.assertEqual(len(executed), 3)
+        self.assertEqual(executed[0], "SET statement_timeout = 9000")
+        self.assertEqual(executed[1], "SET lock_timeout = 1500")
+        self.assertEqual(executed[2], "SET idle_in_transaction_session_timeout = 12000")
         cur.close.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- Split the three `SET ...` statements in `_on_connect` into individual `cur.execute()` calls so the listener works with both `psycopg2` and `asyncpg`. `asyncpg` raises `cannot insert multiple commands into a prepared statement` when handed a multi-statement string, which prevented every connection from being acquired in services using the async engine introduced in 2.8.0.
- Bump version to `2.8.1`.

## Why
Observed in `platform-agreements` UAT after the SQLAlchemy 2.0 / asyncpg migration shipped in 2.8.0: every real request returned 500 (healthcheck unaffected because it does not touch the DB). Full traceback ends in `serpens/database/__init__.py:55` inside `_on_connect`:

```
asyncpg.exceptions.PostgresSyntaxError:
  cannot insert multiple commands into a prepared statement
```

`psycopg2` tolerated multi-statement strings; `asyncpg` does not because it prepares every statement.

## Test plan
- [x] `python -m pytest tests/test_database.py -q` — 21 passed (existing `test_executes_set_statements` updated to assert 3 individual executes)
- [ ] Publish `noverde-serpens==2.8.1` (sdist + wheel already built locally)
- [ ] Bump `noverde-serpens` in `platform-agreements` and redeploy UAT
- [ ] Confirm in Cloud Run logs (`platform-agreements-public-api`, project `dotz-noverde-uat`) that DB-bound routes stop returning 500