### PR TITLE
feat(testgres): opt-in host networking to bypass docker NAT under VPN

### DIFF
--- a/serpens/testgres.py
+++ b/serpens/testgres.py
@@ -24,6 +24,8 @@ testgres_startup_timeout = int(os.getenv("TESTGRES_STARTUP_TIMEOUT", 30))
 container_name = f"testgres_{uuid.uuid4().hex}"
 redis_container_name = f"testredis_{uuid.uuid4().hex}"
 redis_image = os.getenv("TESTGRES_REDIS_IMAGE", "redis:7-alpine")
+testgres_network = os.getenv("TESTGRES_DOCKER_NETWORK", "")
+testgres_port = os.getenv("TESTGRES_PORT", "5433" if testgres_network else "5432")
 
 
 def docker_shell(cmd, output=True):
@@ -37,6 +39,9 @@ def docker_start():
     imgname = "postgres:13"
     cmdargs = f"-d --rm --name {container_name}"
     envvars = "-e POSTGRES_USER=testgres -e POSTGRES_PASSWORD=testgres"
+    if testgres_network:
+        netargs = f"--network {testgres_network} -e PGPORT={testgres_port}"
+        return docker_shell(f"docker run {cmdargs} {netargs} {envvars} {imgname}")
     publish = "-p 5432"
     return docker_shell(f"docker run {cmdargs} {publish} {envvars} {imgname}")
 
@@ -61,6 +66,8 @@ def docker_pg_user_path():
 
 
 def docker_port():
+    if testgres_network:
+        return testgres_port
     stdout = docker_shell(f"docker port {container_name}").stdout
     result = stdout.split("\n")[0]
     return result.split(":")[1]

--- a/tests/test_testgres.py
+++ b/tests/test_testgres.py
@@ -53,6 +53,22 @@ class TestTestgres(unittest.TestCase):
         result = docker_port()
         self.assertEqual(result, "65432")
 
+    @patch("serpens.testgres.container_name", "testgres")
+    @patch("serpens.testgres.testgres_port", "5433")
+    @patch("serpens.testgres.testgres_network", "host")
+    def test_docker_start_host_network(self):
+        self.mrun.return_value.stdout = "OK"
+        docker_start()
+        cmd = " ".join(self.mrun.call_args[0][0])
+        self.assertIn("--network host", cmd)
+        self.assertIn("-e PGPORT=5433", cmd)
+        self.assertNotIn("-p 5432", cmd)
+
+    @patch("serpens.testgres.testgres_port", "5433")
+    @patch("serpens.testgres.testgres_network", "host")
+    def test_docker_port_host_network(self):
+        self.assertEqual(docker_port(), "5433")
+
     def test_docker_pg_isready(self):
         self.mrun.return_value.returncode = 2
         result = docker_pg_isready()


### PR DESCRIPTION
### Contain
- [x] New feature
- [ ] Bugfix
- [x] Tests
- [ ] Documentation
- [ ] Build/CI/CD
- [ ] Breaking changes
- [ ] Refactor
- [ ] Configuration changes
- [ ] Migrations

### Details
* Add opt-in Docker host networking to `testgres` via `TESTGRES_DOCKER_NETWORK` (e.g. `host`) + `TESTGRES_PORT` (default `5433` in host mode). Bypasses docker-proxy/iptables NAT, which makes published ports unreachable when a VPN is active — letting tests run locally under VPN.
* Default behavior unchanged (published port) when the env is unset.

### Task
N/A